### PR TITLE
Fatal crash because grade_anonymous cannot be found

### DIFF
--- a/screens/anonymous/lib.php
+++ b/screens/anonymous/lib.php
@@ -11,7 +11,11 @@ class quick_edit_anonymous extends quick_edit_tablelike
         global $COURSE;
 
         if (is_null(self::$supported)) {
-            self::$supported = grade_anonymous::is_supported($COURSE);
+            if (class_exists('grade_anonymous')) {
+                self::$supported = grade_anonymous::is_supported($COURSE);
+            } else {
+                self::$supported = false;
+            }
         }
 
         return self::$supported;


### PR DESCRIPTION
If you just install the quick_edit block by itself it gives a fatal crash because the grade_anonymous class cannot be found. See attached screen shot.

I just added in a check to see if the class exists before actually calling the static method on the class.

![screen shot 2013-08-23 at 4 25 42 pm](https://f.cloud.github.com/assets/2071843/1019694/2e3b8dac-0c4d-11e3-924d-e0b55a54d0b2.png)
